### PR TITLE
Provide support for self-hosted sentry instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Then, add this line to your application's Capfile:
 require 'capistrano/sentry'
 ```
 
-And then execute:
+And then execute from your command line:
 
-    $ bundle
+```bash
+bundle
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Add these lines to your application's `config/deploy.rb`:
 
 ```ruby
 # Sentry deployment notification
+set :sentry_host, 'https://my-sentry.mycorp.com' # https://sentry.io by default
 set :sentry_api_token, 'd9fe44a1cf34e63993e258dbecf42158918d407978a1bb72f8fb5886aa5f9fe1'
 set :sentry_organization, 'my-org' # fetch(:application) by default
 set :sentry_project, 'my-proj'     # fetch(:application) by default

--- a/lib/capistrano/sentry/version.rb
+++ b/lib/capistrano/sentry/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Sentry
-    VERSION = '0.1.5'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -22,17 +22,18 @@ namespace :sentry do
       require 'net/https'
       require 'json'
 
-      uri = URI.parse('https://sentry.io')
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-
       version = `git rev-parse HEAD`.strip
 
+      sentry_host = ENV["SENTRY_HOST"] || fetch(:sentry_host, 'https://sentry.io')
       orga_slug = fetch(:sentry_organization) || fetch(:application)
       project = fetch(:sentry_project) || fetch(:application)
       environment = fetch(:stage) || 'default'
       api_token = ENV['SENTRY_API_TOKEN'] || fetch(:sentry_api_token)
       repo_name = fetch(:sentry_repo) || fetch(:repo_url).split(':').last.gsub(/\.git$/, '')
+
+      uri = URI.parse(sentry_host)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
 
       headers = {
         'Content-Type' => 'application/json',


### PR DESCRIPTION
Hi there,

This tiny PR provides the ability to set your sentry host to your own instance instead of having it hardcoded to `sentry.io`.

This will allow teams that self-host sentry to use this gem too. The default remains `https://sentry.io` if it's not specified.

Please let me know if you need me to make any other changes. Thank you for this useful gem.