### PR TITLE
doc: Updates to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,27 @@ Add these lines to your application's `config/deploy.rb`:
 ```ruby
 # Sentry deployment notification
 set :sentry_host, 'https://my-sentry.mycorp.com' # https://sentry.io by default
-set :sentry_api_token, 'd9fe44a1cf34e63993e258dbecf42158918d407978a1bb72f8fb5886aa5f9fe1'
+set :sentry_api_token, '0123456789abcdef0123456789abcdef'
 set :sentry_organization, 'my-org' # fetch(:application) by default
 set :sentry_project, 'my-proj'     # fetch(:application) by default
 set :sentry_repo, 'my-org/my-proj' # computed from repo_url by default
 
 after 'deploy:published', 'sentry:notice_deployment'
 ```
+
+* `sentry_host`: identifies to which host Sentry submissions are sent. [https://sentry.io by default]
+
+* `sentry_api_token`: Deploy Tokens are project-specific and can be found on Sentry's Project Release Tracking
+ page (`Project Settings > SDK Setup > Releases > Deploy Token`).
+ [https://sentry.io/settings/{ORGANIZATION_SLUG}/projects/{PROJECT_SLUG}/release-tracking/]
+
+* `sentry_organization`: The "**Name**" ("*A unique ID used to identify this organization*") from Sentry's Organization Settings page.
+[https://sentry.io/settings/{ORGANIZATION_SLUG}]
+
+* `sentry_project`: The "**Name**" ("*A unique ID used to identify this project*") from Sentry's Project Settings page.
+[https://sentry.io/settings/{ORGANIZATION_SLUG}/projects/{PROJECT_SLUG}]
+
+* `sentry_repo`: The `repository` name to be used when reporting repository details to Sentry [computed from `fetch(:repo_url)` by default -- `https://github.com/codeur/capistrano-sentry` becomes `//github.com/codeur/capistrano-sentry` and `git@github.com:codeur/capistrano-sentry.git` becomes `codeur/capistrano-sentry`]
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,14 @@ set :sentry_api_token, '0123456789abcdef0123456789abcdef'
 set :sentry_organization, 'my-org' # fetch(:application) by default
 set :sentry_project, 'my-proj'     # fetch(:application) by default
 set :sentry_repo, 'my-org/my-proj' # computed from repo_url by default
+```
 
+If you want deployments to be published in every Rails environment, put this in `config/deploy.rb`, otherwise put it your environment-specific deploy file (i.e. `config/deploy/production.rb`):
+```ruby
 after 'deploy:published', 'sentry:notice_deployment'
 ```
+
+### Explaination of Configuration Properties
 
 * `sentry_host`: identifies to which host Sentry submissions are sent. [https://sentry.io by default]
 
@@ -53,6 +58,10 @@ after 'deploy:published', 'sentry:notice_deployment'
 [https://sentry.io/settings/{ORGANIZATION_SLUG}/projects/{PROJECT_SLUG}]
 
 * `sentry_repo`: The `repository` name to be used when reporting repository details to Sentry [computed from `fetch(:repo_url)` by default -- `https://github.com/codeur/capistrano-sentry` becomes `//github.com/codeur/capistrano-sentry` and `git@github.com:codeur/capistrano-sentry.git` becomes `codeur/capistrano-sentry`]
+
+### Sentry API Documentation
+* [Project Releases](https://docs.sentry.io/api/releases/post-project-releases/)
+* [Release Deploys](https://docs.sentry.io/api/releases/post-release-deploys/)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ after 'deploy:published', 'sentry:notice_deployment'
 
 * `sentry_host`: identifies to which host Sentry submissions are sent. [https://sentry.io by default]
 
-* `sentry_api_token`: Deploy Tokens are project-specific and can be found on Sentry's Project Release Tracking
- page (`Project Settings > SDK Setup > Releases > Deploy Token`).
- [https://sentry.io/settings/{ORGANIZATION_SLUG}/projects/{PROJECT_SLUG}/release-tracking/]
+* `sentry_api_token`: API Auth Tokens are found/created in you Sentry Account Settings (not in the organization or project): `Settings > Account > Api > Auth Tokens`.
+ [https://sentry.io/settings/account/api/auth-tokens/]
 
 * `sentry_organization`: The "**Name**" ("*A unique ID used to identify this organization*") from Sentry's Organization Settings page.
 [https://sentry.io/settings/{ORGANIZATION_SLUG}]

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -62,8 +62,3 @@ namespace :sentry do
     end
   end
 end
-
-# If you want deployments to be published in every Rails environment, put this
-# in config/deploy.rb, otherwise put it your environment-specific deploy file
-# i.e. config/deploy/production.rb
-# after 'deploy:published', 'sentry:notice_deployment'

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -1,8 +1,9 @@
-# This task will notify Sentry via their API[1] that you have deployed
+# This task will notify Sentry via their API[1][2] that you have deployed
 # a new release. It uses the commit hash as the `version` and the git ref as
 # the optional `ref` value.
 #
-# [1]: https://docs.getsentry.com/hosted/api/releases/post-project-releases
+# [1]: https://docs.sentry.io/api/releases/post-project-releases/
+# [2]: https://docs.sentry.io/api/releases/post-release-deploys/
 
 # For Rails app, this goes in config/deploy.rb
 


### PR DESCRIPTION
* Add descriptions of config options.
* Update reference links to Sentry API documentation.
* Move documentation from Rake task to `README`

Completes #2.