### PR TITLE
Validate config before starting deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Simple extension of capistrano for automatic notification of Sentry.
 
-TODO: Prevent user at deployment start if missing parameter to inform sentry
-      properly
-
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
"TODO: Prevent user at deployment start if missing parameter to inform sentry properly" -- from [`README`](https://github.com/codeur/capistrano-sentry#readme)

This should do the trick.