### PR TITLE
Additional optional config and optional repo integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ after 'deploy:published', 'sentry:notice_deployment'
 
 * `sentry_repo`: The `repository` name to be used when reporting repository details to Sentry [computed from `fetch(:repo_url)` by default -- `https://github.com/codeur/capistrano-sentry` becomes `//github.com/codeur/capistrano-sentry` and `git@github.com:codeur/capistrano-sentry.git` becomes `codeur/capistrano-sentry`]
 
+* `sentry_repo_integration`: this enables/disables submission of git repo information (`release_refs` below) to Sentry [Enabled (`true`) by default].
+
+* `sentry_release_refs`: Repository details about this realease (`repository`, `commit`, `previousCommit`) to Sentry [computed from `sentry_repo`, `current_revision`, and `previous_revision`)].
+
+* `sentry_release_version`: Version number (tag, etc.) used to identify this release to Sentry [computed from `current_revision` or repository `HEAD`)].
+
+* `deploy_name`: A name (revision, version number, tag, etc.) used to identify this release deploy to Sentry [computed from `sentry_release_version`+`fetch(:release_timestamp)`)].
+
 ### Sentry API Documentation
 * [Project Releases](https://docs.sentry.io/api/releases/post-project-releases/)
 * [Release Deploys](https://docs.sentry.io/api/releases/post-release-deploys/)

--- a/capistrano-sentry.gemspec
+++ b/capistrano-sentry.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |spec|
   spec.version       = Capistrano::Sentry::VERSION
   spec.authors       = ['Brice Texier']
   spec.email         = ['brice@codeur.com']
-
+  spec.description   = 'Sentry release/deployment integration'
   spec.summary       = 'Sentry release/deployment integration'
   spec.homepage      = 'https://github.com/codeur/capistrano-sentry'
   spec.license       = 'MIT'

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -49,7 +49,7 @@ namespace :sentry do
       req.body = JSON.generate(body)
       response = http.request(req)
       if response.is_a? Net::HTTPSuccess
-        info 'Uploaded release infos to Sentry'
+        info "Notified Sentry of new release: #{release_version}"
         req = Net::HTTP::Post.new("/api/0/organizations/#{organization_slug}/releases/#{release_version}/deploys/", headers)
         req.body = JSON.generate(
           environment: environment,
@@ -57,7 +57,7 @@ namespace :sentry do
         )
         response = http.request(req)
         if response.is_a? Net::HTTPSuccess
-          info 'Uploaded deployment infos to Sentry'
+          info "Notified Sentry of new deployment: #{deploy_name}"
         else
           warn "Cannot notify sentry for new deployment. Response: #{response.code.inspect}: #{response.body}"
         end

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -16,6 +16,7 @@ namespace :sentry do
       require 'json'
 
       head_revision = fetch(:current_revision) || `git rev-parse HEAD`.strip
+      prev_revision = fetch(:previous_revision) || `git rev-parse #{fetch(:current_revision)}^`.strip
 
       sentry_host = ENV['SENTRY_HOST'] || fetch(:sentry_host, 'https://sentry.io')
       organization_slug = fetch(:sentry_organization) || fetch(:application)
@@ -25,8 +26,8 @@ namespace :sentry do
       repo_integration_enabled = fetch(:sentry_repo_integration, true)
       release_refs = fetch(:sentry_release_refs, [{
         repository: fetch(:sentry_repo) || fetch(:repo_url).split(':').last.gsub(/\.git$/, ''),
-        commit: fetch(:current_revision) || head_revision,
-        previousCommit: fetch(:previous_revision),
+        commit: head_revision,
+        previousCommit: prev_revision,
       }])
       release_version = fetch(:sentry_release_version) || head_revision
       deploy_name = fetch(:sentry_deploy_name) || "#{release_version}-#{fetch(:release_timestamp)}"


### PR DESCRIPTION
This allows overriding some defaults with additional config (`:current_revision`, `:previous_revision`, `:sentry_release_version`, `:deploy_name`). Also, for those without repo integration on Sentry, this can be bypassed by `set :sentry_repo_integration, false` in `config/deploy.rb` or `config/deploy/{stage}.rb`.

I not sure it you want this, but I'm finding it useful. 