### PR TITLE
Feature: Support multiple project slugs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ after 'deploy:published', 'sentry:notice_deployment'
 * `sentry_organization`: The "**Name**" ("*A unique ID used to identify this organization*") from Sentry's Organization Settings page.
 [https://sentry.io/settings/{ORGANIZATION_SLUG}]
 
-* `sentry_project`: The "**Name**" ("*A unique ID used to identify this project*") from Sentry's Project Settings page.
+* `sentry_project`: The "**Name**" ("*A unique ID used to identify this project*") from Sentry's Project Settings page. Separate multiple projects names by whitespace.
 [https://sentry.io/settings/{ORGANIZATION_SLUG}/projects/{PROJECT_SLUG}]
 
 * `sentry_repo`: The `repository` name to be used when reporting repository details to Sentry [computed from `fetch(:repo_url)` by default -- `https://github.com/codeur/capistrano-sentry` becomes `//github.com/codeur/capistrano-sentry` and `git@github.com:codeur/capistrano-sentry.git` becomes `codeur/capistrano-sentry`]

--- a/capistrano-sentry.gemspec
+++ b/capistrano-sentry.gemspec
@@ -14,6 +14,9 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/codeur/capistrano-sentry'
   spec.license       = 'MIT'
 
+  # Required for String.delete_suffix.
+  spec.required_ruby_version = '>= 2.5.0'
+
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do

--- a/lib/capistrano-sentry.rb
+++ b/lib/capistrano-sentry.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+# empty

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -65,7 +65,7 @@ namespace :sentry do
       req = Net::HTTP::Post.new("/api/0/organizations/#{organization_slug}/releases/", headers)
       body = {
         version:  release_version,
-        projects: [project]
+        projects: project.split(' ').reject(&:empty?)
       }
       body[:refs] = release_refs if repo_integration_enabled
       req.body = JSON.generate(body)

--- a/lib/capistrano/tasks/sentry.rake
+++ b/lib/capistrano/tasks/sentry.rake
@@ -59,7 +59,7 @@ namespace :sentry do
 
       headers = {
         'Content-Type'  => 'application/json',
-        'Authorization' => 'Bearer ' + api_token.to_s
+        'Authorization' => "Bearer #{api_token}"
       }
 
       req = Net::HTTP::Post.new("/api/0/organizations/#{organization_slug}/releases/", headers)


### PR DESCRIPTION
Hey there,

First of all: Thanks for this repo!

This PR:
- allows that by supporting to set a whitespace separated list of project slugs (`set :sentry_project, 'my-foo my-bar'`),
- fixes existing rubocop offenses because I assumed that the existing `.rubocop.yml` is not deprecated and
- sets a required ruby version via `spec.required_ruby_version = '>= 2.5.0'` because I noticed that the code would fail running on 2.4.9 because of `String.delete_suffix` usage.

Reasoning: I found myself in a position where I have separate frontend and backend projects in Sentry (to allow users to fine tune their notifications more easily), but one git repository for both project's code ("historical reasons"). Therefore I need to notify Sentry about one release being deployed to both projects. This PR intends to support exactly that.

Please let me know if i should split up these changes into several PRs or if any other changes are required.


Thanks!